### PR TITLE
fixed issue with accented characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ const PokedexIntentHandler = {
 };
 
  const GetPokemon = async function (pokemon) {
+     //needed to replace the accented characters and to lowercase the string that comes from alexa
+     pokemon = pokemon.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
      return new Promise(((resolve, reject) => {
         var options = {
             host: 'pokeapi.co',


### PR DESCRIPTION
Issues raised by amazon 

steps to reproduce
User:"Alexa, start fan pokedex"
Skill:"Welcome, what pokemon would you like to hear more about?"
User:"tell me about pikachu"
Actual Result:Skill responds, "Sorry, I had trouble doing what you asked. Please try again." and the session remains open for the user to prompt another input.


after looking into it pikachu was coming back from alexa as Pikachū with accent on the U and the upper case 'P' causing an issue when using that as part of the url request to PokeApi.

this fix removes accented characters by first splitting them up into the the accent and the character then removing the accent. it then turns the whole string into lowercase characters.